### PR TITLE
3.0.0

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -2,6 +2,7 @@
   "module": {
     "type": "commonjs"
   },
+
   "jsc": {
     "parser": {
       "syntax": "typescript",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# [3.0.0-alpha.1](https://github.com/sorry-cypress/cy2/compare/v3.0.0-alpha.0...v3.0.0-alpha.1) (2022-10-20)
+
 # [3.0.0-alpha.0](https://github.com/sorry-cypress/cy2/compare/v2.1.0...v3.0.0-alpha.0) (2022-10-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [3.0.0-alpha.0](https://github.com/sorry-cypress/cy2/compare/v2.1.0...v3.0.0-alpha.0) (2022-10-20)
+
+
+### Features
+
+* allow init script injection ([113a58b](https://github.com/sorry-cypress/cy2/commit/113a58b8ec7dbf0c9d4f0e3d32d1f8140d634261))
+
+
+### BREAKING CHANGES
+
+* - Module API has changed - the absolute location of an injected module is expected instead of CYPRESS_API_URL
+- `bin/cy2` requires CYPRESS_API_URL environment variable, otherwise throws
+
 # [2.1.0](https://github.com/sorry-cypress/cy2/compare/v2.0.1...v2.1.0) (2022-10-19)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,111 +1,90 @@
 # [3.0.0-alpha.2](https://github.com/sorry-cypress/cy2/compare/v3.0.0-alpha.1...v3.0.0-alpha.2) (2022-10-21)
 
-
 ### Features
 
-* implement patch and update README ([ad95e9d](https://github.com/sorry-cypress/cy2/commit/ad95e9d379138c77abaa8596452c14d90be73f51))
+- implement patch and update README ([ad95e9d](https://github.com/sorry-cypress/cy2/commit/ad95e9d379138c77abaa8596452c14d90be73f51))
 
 # [3.0.0-alpha.1](https://github.com/sorry-cypress/cy2/compare/v3.0.0-alpha.0...v3.0.0-alpha.1) (2022-10-20)
 
 # [3.0.0-alpha.0](https://github.com/sorry-cypress/cy2/compare/v2.1.0...v3.0.0-alpha.0) (2022-10-20)
 
-
 ### Features
 
-* allow init script injection ([113a58b](https://github.com/sorry-cypress/cy2/commit/113a58b8ec7dbf0c9d4f0e3d32d1f8140d634261))
-
+- allow init script injection ([113a58b](https://github.com/sorry-cypress/cy2/commit/113a58b8ec7dbf0c9d4f0e3d32d1f8140d634261))
 
 ### BREAKING CHANGES
 
-* - Module API has changed - the absolute location of an injected module is expected instead of CYPRESS_API_URL
-- `bin/cy2` requires CYPRESS_API_URL environment variable, otherwise throws
+- Starting version 3+, the API methods `run` and `patch` rely on `process.env.CYPRESS_API_URL` - they do not accept any argument. That's because of a new patching method that doesn't permanently change cypress installation after invoking `cy2`.
+- CLI executable script `cy2` requires CYPRESS_API_URL environment variable, otherwise throws
 
 # [2.1.0](https://github.com/sorry-cypress/cy2/compare/v2.0.1...v2.1.0) (2022-10-19)
 
-
 ### Features
 
-* restore original cypress config on exit ([64086da](https://github.com/sorry-cypress/cy2/commit/64086da4347ebdf28a87a281d8187e17bb927b65))
+- restore original cypress config on exit ([64086da](https://github.com/sorry-cypress/cy2/commit/64086da4347ebdf28a87a281d8187e17bb927b65))
 
 ## [2.0.1](https://github.com/sorry-cypress/cy2/compare/v1.3.0...v2.0.1) (2022-08-28)
 
-
-* 2.0.0 (#20) ([7846d42](https://github.com/sorry-cypress/cy2/commit/7846d42a2010398f41861fb0f6bf3f92be2b6999)), closes [#20](https://github.com/sorry-cypress/cy2/issues/20)
-
+- 2.0.0 (#20) ([7846d42](https://github.com/sorry-cypress/cy2/commit/7846d42a2010398f41861fb0f6bf3f92be2b6999)), closes [#20](https://github.com/sorry-cypress/cy2/issues/20)
 
 ### BREAKING CHANGES
 
-* bumping major for safe release, no API changes
+- bumping major for safe release, no API changes
 
-* Release 2.0.0-beta.0
+- Release 2.0.0-beta.0
 
-* Support CYPRESS_RUN_BINARY
+- Support CYPRESS_RUN_BINARY
 
-* Release 2.0.0
+- Release 2.0.0
 
 # [2.0.0](https://github.com/sorry-cypress/cy2/compare/v2.0.0-beta.0...v2.0.0) (2022-03-29)
 
 # [2.0.0-beta.0](https://github.com/sorry-cypress/cy2/compare/v1.3.0...v2.0.0-beta.0) (2021-09-12)
 
-
 ### Features
 
-* add more discovery strategies ([f3d3b09](https://github.com/sorry-cypress/cy2/commit/f3d3b09e001578e768f7f1aac8932d57427e05c8))
-* use CYPRESS_PACKAGE_CONFIG_PATH ([743a892](https://github.com/sorry-cypress/cy2/commit/743a892662aa9586ee52df2cdb6eee6479abdd7e))
-
+- add more discovery strategies ([f3d3b09](https://github.com/sorry-cypress/cy2/commit/f3d3b09e001578e768f7f1aac8932d57427e05c8))
+- use CYPRESS_PACKAGE_CONFIG_PATH ([743a892](https://github.com/sorry-cypress/cy2/commit/743a892662aa9586ee52df2cdb6eee6479abdd7e))
 
 ### BREAKING CHANGES
 
-* bumping major for safe release, no API changes
+- bumping major for safe release, no API changes
 
 # [1.3.0](https://github.com/sorry-cypress/cy2/compare/v1.2.1...v1.3.0) (2021-09-08)
 
-
 ### Features
 
-* add debug ([#15](https://github.com/sorry-cypress/cy2/issues/15)) ([c455cd5](https://github.com/sorry-cypress/cy2/commit/c455cd531f8ee3c255e81efae9de91a4065a6d40))
-* use __dirname instead of cwd ([#14](https://github.com/sorry-cypress/cy2/issues/14)) ([95561ea](https://github.com/sorry-cypress/cy2/commit/95561ea14362260be0dd6627f1697c3d86007d4d))
+- add debug ([#15](https://github.com/sorry-cypress/cy2/issues/15)) ([c455cd5](https://github.com/sorry-cypress/cy2/commit/c455cd531f8ee3c255e81efae9de91a4065a6d40))
+- use \_\_dirname instead of cwd ([#14](https://github.com/sorry-cypress/cy2/issues/14)) ([95561ea](https://github.com/sorry-cypress/cy2/commit/95561ea14362260be0dd6627f1697c3d86007d4d))
 
 ## [1.2.1](https://github.com/sorry-cypress/cy2/compare/v1.2.0...v1.2.1) (2021-05-11)
 
 # [1.2.0](https://github.com/sorry-cypress/cy2/compare/v1.1.0...v1.2.0) (2021-05-11)
 
-
 ### Bug Fixes
 
-* fix windows and add readme ([53adfad](https://github.com/sorry-cypress/cy2/commit/53adfad6fbc73902a34320966d53e2799e94b430))
-
+- fix windows and add readme ([53adfad](https://github.com/sorry-cypress/cy2/commit/53adfad6fbc73902a34320966d53e2799e94b430))
 
 ### Features
 
-* add e2e tests ([d3e45a1](https://github.com/sorry-cypress/cy2/commit/d3e45a16ea5b6afdf2252fb456157a2e1386a4fd))
-
-
+- add e2e tests ([d3e45a1](https://github.com/sorry-cypress/cy2/commit/d3e45a16ea5b6afdf2252fb456157a2e1386a4fd))
 
 # [1.1.0](https://github.com/sorry-cypress/cy2/compare/v1.1.0...v1.2.0) (2021-05-08)
 
-
 ### Features
 
-* export run and patch from index ([e540940](https://github.com/sorry-cypress/cy2/commit/e5409406073064b7e00e50e19aff5a0662bf8324)), closes [#4](https://github.com/sorry-cypress/cy2/issues/4)
-
-
+- export run and patch from index ([e540940](https://github.com/sorry-cypress/cy2/commit/e5409406073064b7e00e50e19aff5a0662bf8324)), closes [#4](https://github.com/sorry-cypress/cy2/issues/4)
 
 # [1.1.0-beta.0](https://github.com/sorry-cypress/cy2/compare/v1.1.0...v1.2.0) (2021-04-30)
 
-
 ### Features
 
-* add `cy.patch(api)` export ([6712541](https://github.com/sorry-cypress/cy2/commit/6712541fb8e44580ec5f80d8758fbbaecbe29c11))
-
-
+- add `cy.patch(api)` export ([6712541](https://github.com/sorry-cypress/cy2/commit/6712541fb8e44580ec5f80d8758fbbaecbe29c11))
 
 ## [1.0.5](https://github.com/sorry-cypress/cy2/compare/v1.1.0...v1.2.0) (2021-04-30)
 
-
 ### Bug Fixes
 
-* add trailing slash for the default url ([fa70900](https://github.com/sorry-cypress/cy2/commit/fa70900e50667c475614e6fe6105189f1f27bbe5))
-* exit with child's exit code ([8a09906](https://github.com/sorry-cypress/cy2/commit/8a0990603d22d8cbad833b8efe68dd93a1437cac)), closes [#5](https://github.com/sorry-cypress/cy2/issues/5)
-* spawn and inherit io ([7273f9d](https://github.com/sorry-cypress/cy2/commit/7273f9d97c81848aa5f87725b18486be15221b4e))
-
+- add trailing slash for the default url ([fa70900](https://github.com/sorry-cypress/cy2/commit/fa70900e50667c475614e6fe6105189f1f27bbe5))
+- exit with child's exit code ([8a09906](https://github.com/sorry-cypress/cy2/commit/8a0990603d22d8cbad833b8efe68dd93a1437cac)), closes [#5](https://github.com/sorry-cypress/cy2/issues/5)
+- spawn and inherit io ([7273f9d](https://github.com/sorry-cypress/cy2/commit/7273f9d97c81848aa5f87725b18486be15221b4e))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [3.0.0-alpha.2](https://github.com/sorry-cypress/cy2/compare/v3.0.0-alpha.1...v3.0.0-alpha.2) (2022-10-21)
+
+
+### Features
+
+* implement patch and update README ([ad95e9d](https://github.com/sorry-cypress/cy2/commit/ad95e9d379138c77abaa8596452c14d90be73f51))
+
 # [3.0.0-alpha.1](https://github.com/sorry-cypress/cy2/compare/v3.0.0-alpha.0...v3.0.0-alpha.1) (2022-10-20)
 
 # [3.0.0-alpha.0](https://github.com/sorry-cypress/cy2/compare/v2.1.0...v3.0.0-alpha.0) (2022-10-20)

--- a/README.md
+++ b/README.md
@@ -37,83 +37,19 @@ Example usage with [sorry-cypress](https://sorry-cypress.dev)
 CYPRESS_API_URL="https://sorry-cypress-demo-director.herokuapp.com" cy2 run  --parallel --record --key somekey --ci-build-id hello-cypress
 ```
 
-When `CYPRESS_API_URL` is not set, it just uses the default API server `https://api.cypress.io`
+⚠️ `CYPRESS_API_URL` is required
 
 ## API
 
-### Patch Cypress
+### Run Cypress with an injected module
 
 ```ts
-/**
- * Patch Cypress with a custom API URL.
- *
- * Tries to discover the location of `app.yml`
- * and patch it with a custom URL.
- *
- * @param {string} apiURL - new API URL to use
- * @param {string} [cypressConfigFilePath] - explicitly provide the path to Cypress app.yml and disable auto-discovery
- */
-patch(apiURL: string, cypressConfigPath?: string) => Promise<void>
+import { run } from 'cy2';
+
+run(`${__dirname}/injected.js`).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 ```
 
-Example
-
-```js
-const { patch } = require("cy2");
-
-async function main() {
-  await patch("https://sorry-cypress-demo-director.herokuapp.com");
-}
-
-main().catch(console.error);
-```
-
-### Patch and run cypress
-
-```ts
-/**
- * Run Cypress programmatically as a child process
- */
-run(apiURL?: string = 'https://api.cypress.io/'), label?: string = 'cy2')=> Promise<void>
-```
-
-Example
-
-```js
-#!/usr/bin/env node
-
-/* cmd.js */
-
-const { run } = require("cy2");
-
-async function main() {
-  await run("https://sorry-cypress-demo-director.herokuapp.com/", "myCMD");
-}
-
-main().catch(console.error);
-/*
-
-$ ./cmd.js --help
-[myCMD] Running cypress with API URL: https://sorry-cypress-demo-director.herokuapp.com/
-Usage: cypress <command> [options]
-
-Options:
-  -v, --version      prints Cypress version
-  -h, --help         display help for command
-
-*/
-```
-
-## Explicit config file location (since 1.4.0)
-
-Sometimes `cy2` is not able to automatically detect the location of cypress package on your system. In that case you should explicitly provide environment variable `CYPRESS_PACKAGE_CONFIG_PATH` with the location of cypress's `app.yml` configuration file.
-
-Example:
-
-```sh
-CYPRESS_API_URL="http://localhost:1234/" \
-CYPRESS_PACKAGE_CONFIG_PATH="/Users/John/Cypress/8.3.0/Cypress.app/Contents/Resources/app/packages/server/config/app.yml" \
-npx cy2 run --parallel --record --key somekey --ci-build-id hello-cypress
-```
-
-See [cypress agent configuration](https://docs.sorry-cypress.dev/cypress-agent/configuring-cypress-agent) for locating `app.yml` file on your system.
+The injected module will be `require`d by cypress' NodeJS process before everything else. The value should be an absolute path to a compiled CommonJS module. Suitable for monkey-patching and overriding the default Cypress functionality.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 ---
 
+Change cypress configuration to use an alternative dashboard service (Sorry Cypress or Currents).
+
+---
+
 <p align="center">
 Run millions of cypress tests in parallel without breaking the bank
 </p>
@@ -15,7 +19,7 @@ Run millions of cypress tests in parallel without breaking the bank
 
 ---
 
-Change cypress API URL configuration on-the-fly using environment variable `CYPRESS_API_URL`. It passes down all the CLI flags as-is, so you can just use it instead of cypress.
+`cy2` wil read the environment variable `CYPRESS_API_URL` and change cypress configuration accordingly. It passes down all the CLI flags **as-is** and runs cypress with all the flags.
 
 `CYPRESS_API_URL` should point to Sorry Cypress director service, Currents dashboard or other compatible service.
 
@@ -62,13 +66,13 @@ run().catch((error) => {
 
 ### Patch Cypress without running
 
-⚠️ Make sure to set `process.env.CYPRESS_API_URL` before invoking
+⚠️ Make sure to set `process.env.CYPRESS_API_URL` before invoking `patch`
 
 ```ts
 import { patch } from 'cy2';
 import cypress from 'cypress';
 
-process.env.CYPRESS_API_URL = 'https://dashboard.servuce.url';
+process.env.CYPRESS_API_URL = 'https://dashboard.service.url';
 
 async function main() {
   await patch();

--- a/bin/cy2
+++ b/bin/cy2
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-const lib = require('../dist');
+const lib = require('../dist/cli');
 
-lib.run(process.env.CYPRESS_API_URL).catch((error) => {
+lib.runCY2().catch((error) => {
   console.error(error);
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cy2",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "author": "Andrew Goldis",
   "main": "./dist",
   "typings": "./dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cy2",
-  "version": "2.1.0",
+  "version": "3.0.0-alpha.0",
   "author": "Andrew Goldis",
   "main": "./dist",
   "typings": "./dist",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
+    "acorn": "^8.8.0",
     "debug": "^4.3.2",
-    "js-yaml": "^4.0.0",
+    "escodegen": "^2.0.0",
+    "estraverse": "^5.3.0",
     "npm-which": "^3.0.1"
   },
   "files": [
@@ -47,6 +49,7 @@
     "@swc/core": "^1.2.85",
     "@swc/jest": "^0.2.3",
     "@types/debug": "^4.1.7",
+    "@types/estree": "^1.0.0",
     "@types/jest": "^27.0.1",
     "@types/js-yaml": "^4.0.3",
     "@types/node": "^16.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cy2",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "author": "Andrew Goldis",
   "main": "./dist",
   "typings": "./dist",

--- a/src/__tests__/ast.spec.ts
+++ b/src/__tests__/ast.spec.ts
@@ -1,0 +1,47 @@
+import { FN_ID, hasInjected, instrumentCypressInit, parseJS } from '../js';
+const nonPatchedFile = `
+process.env.CYPRESS_INTERNAL_ENV =
+  process.env.CYPRESS_INTERNAL_ENV || "production";
+require("./packages/server");
+`;
+
+const patchedFile = `
+(
+  function ${FN_ID}() {
+    try { 
+        require('oldPath.js');
+    } catch (e) {
+        // noop;
+    }
+}
+)();
+
+process.env.CYPRESS_INTERNAL_ENV =
+  process.env.CYPRESS_INTERNAL_ENV || "production";
+require("./packages/server");
+`;
+
+const result = `(function ${FN_ID}() {
+    try {
+        require('foo');
+    } catch (e) {
+    }
+}());
+process.env.CYPRESS_INTERNAL_ENV = process.env.CYPRESS_INTERNAL_ENV || 'production';
+require('./packages/server');`;
+
+test('should return false for non-injected code', () => {
+  expect(hasInjected(parseJS(nonPatchedFile))).toEqual(false);
+});
+
+test('should return true for injected code', () => {
+  expect(hasInjected(parseJS(patchedFile))).toEqual(true);
+});
+
+test('should inject new code', async () => {
+  expect(instrumentCypressInit(nonPatchedFile, 'foo')).toEqual(result);
+});
+
+test('should replace existing code', async () => {
+  expect(instrumentCypressInit(patchedFile, 'foo')).toEqual(result);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,5 +6,5 @@ export const runCY2 = async () => {
       'Missing CYPRESS_API_URL environment variable pointing to sorry-cypress director serice'
     );
   }
-  await run(`${__dirname}/injected.js`);
+  await run();
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,10 @@
+import { run } from './index';
+
+export const runCY2 = async () => {
+  if (!process.env.CYPRESS_API_URL) {
+    throw new Error(
+      'Missing CYPRESS_API_URL environment variable pointing to sorry-cypress director serice'
+    );
+  }
+  await run(`${__dirname}/injected.js`);
+};

--- a/src/discovery-cli.ts
+++ b/src/discovery-cli.ts
@@ -1,9 +1,22 @@
 import cp from 'child_process';
-import path from 'path';
 import { platform } from 'os';
+import path from 'path';
 import { debug } from './debug';
 
 import { getCypressCLIBinPath } from './bin-path';
+
+export async function getServerInitPath_cli() {
+  debug('Trying discovery via cypress CLI');
+  const cliBinPath = await getCypressCLIBinPath();
+
+  const basePath = await getBasePath(cliBinPath);
+  debug('Cypress base path is: %s', basePath);
+
+  const version = await getCypressVersion(cliBinPath);
+  debug('Cypress version is: %s', version);
+
+  return path.resolve(basePath, version, getPackagedPath(), 'index.js');
+}
 
 export async function getConfigFilesPaths_cli() {
   debug('Trying discovery via cypress CLI');
@@ -19,14 +32,14 @@ export async function getConfigFilesPaths_cli() {
     basePath,
     version,
     getPackagedPath(),
-    'app.yml'
+    'packages/server/config/app.yml'
   );
 
   const backupConfigFilePath = path.resolve(
     basePath,
     version,
     getPackagedPath(),
-    '_app.yml'
+    'packages/server/config/_app.yml'
   );
 
   return {
@@ -55,9 +68,9 @@ async function getCypressVersion(binPath: string) {
 
 function getPackagedPath() {
   if (platform() === 'win32') {
-    return 'Cypress/resources/app/packages/server/config';
+    return 'Cypress/resources/app';
   }
-  return 'Cypress.app/Contents/Resources/app/packages/server/config';
+  return 'Cypress.app/Contents/Resources/app';
 }
 
 function execute(command): Promise<string> {

--- a/src/discovery-run-binary.ts
+++ b/src/discovery-run-binary.ts
@@ -1,8 +1,7 @@
-import { platform } from 'os';
 import fs from 'fs';
+import { platform } from 'os';
 import path from 'path';
-import { debug } from './debug';
-import { getConfigFiles } from './files';
+import { getConfigFiles, getServerInit } from './files';
 
 export function getPkgRootFromElectronBinary(binaryPath: string): string {
   fs.statSync(binaryPath);
@@ -34,4 +33,9 @@ export function getPkgRootFromElectronBinary(binaryPath: string): string {
 export function getConfigFromElectronBinary(binaryPath: string) {
   fs.statSync(binaryPath);
   return getConfigFiles(getPkgRootFromElectronBinary(binaryPath));
+}
+
+export function getServerInitFromElectronBinary(binaryPath: string) {
+  fs.statSync(binaryPath);
+  return getServerInit(getPkgRootFromElectronBinary(binaryPath));
 }

--- a/src/discovery-state-module.ts
+++ b/src/discovery-state-module.ts
@@ -1,9 +1,24 @@
 import path from 'path';
 
-import { debug } from './debug';
 import { getCypressCLIBinPath } from './bin-path';
+import { debug } from './debug';
+import { getConfigFiles, getServerInit } from './files';
 import { lookupPaths } from './fs';
-import { getConfigFiles } from './files';
+
+export async function getServerInitPaths_stateModule() {
+  debug('Trying discovery via state module');
+
+  const stateModulePath = await getStateModulePath();
+  const state = require(stateModulePath);
+
+  const pkgPath = state.getBinaryPkgPath(state.getBinaryDir());
+  debug('Cypress pkgPath: %s', pkgPath);
+
+  const pkgRoot = path.dirname(pkgPath);
+  debug('Cypress pkgRoot: %s', pkgRoot);
+
+  return getServerInit(pkgRoot);
+}
 
 export async function getConfigFilesPaths_stateModule() {
   debug('Trying discovery via state module');

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -3,9 +3,18 @@ import fs from 'fs';
 import path from 'path';
 import { debug } from './debug';
 
-import { getConfigFilesPaths_cli } from './discovery-cli';
-import { getConfigFromElectronBinary } from './discovery-run-binary';
-import { getConfigFilesPaths_stateModule } from './discovery-state-module';
+import {
+  getConfigFilesPaths_cli,
+  getServerInitPath_cli,
+} from './discovery-cli';
+import {
+  getConfigFromElectronBinary,
+  getServerInitFromElectronBinary,
+} from './discovery-run-binary';
+import {
+  getConfigFilesPaths_stateModule,
+  getServerInitPaths_stateModule,
+} from './discovery-state-module';
 
 export async function getConfigFilesPaths(
   cypressConfigFilePath: string | null = null
@@ -35,6 +44,17 @@ export async function getConfigFilesPaths(
   }
 
   return tryAll(getConfigFilesPaths_stateModule, getConfigFilesPaths_cli);
+}
+
+export async function getServerInitPath(): Promise<string> {
+  if (typeof process.env.CYPRESS_RUN_BINARY === 'string') {
+    debug('CYPRESS_RUN_BINARY: %s', process.env.CYPRESS_RUN_BINARY);
+    return tryAll(() =>
+      getServerInitFromElectronBinary(process.env.CYPRESS_RUN_BINARY as string)
+    );
+  }
+
+  return tryAll(getServerInitPaths_stateModule, getServerInitPath_cli);
 }
 
 async function tryAll(...fns) {

--- a/src/files.ts
+++ b/src/files.ts
@@ -22,3 +22,9 @@ export const getConfigFiles = (pkgRoot: string): ConfigFiles => {
     backupConfigFilePath,
   };
 };
+
+export const getServerInit = (pkgRoot: string): string => {
+  const result = path.resolve(pkgRoot, 'index.js');
+  debug('Cypress installation server init: %s', result);
+  return result;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import * as lib from './patch';
 
-// TODO: implement permanent patch solution
-// export const patch = lib.patch;
+export const patch = async () => {
+  await lib.patchServerInit(`${__dirname}/injected.js`);
+};
 
-export const run = async (moduleAbsolutePath: string) => {
-  await lib.patchServerInit(moduleAbsolutePath);
+export const run = async () => {
+  await lib.patchServerInit(`${__dirname}/injected.js`);
   await lib.run();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,9 @@
 import * as lib from './patch';
 
-const DEFAULT_OVERRIDE_URL = 'https://api.cypress.io/';
+// TODO: implement permanent patch solution
+// export const patch = lib.patch;
 
-export const patch = lib.patch;
-
-export const run = async (
-  cypressAPIUrl = DEFAULT_OVERRIDE_URL,
-  label = 'cy2',
-  cypressConfigFilePath = process.env.CYPRESS_PACKAGE_CONFIG_PATH
-) => {
-  await lib.patch(cypressAPIUrl, cypressConfigFilePath);
-
-  console.log(`[${label}] Running cypress with API URL: ${cypressAPIUrl}`);
-
-  const child = await lib.run();
-
-  child.on('close', async (code) => {
-    await patch(DEFAULT_OVERRIDE_URL);
-    process.exit(code ?? 1);
-  });
-  process.on('SIGINT', async () => {
-    await patch(DEFAULT_OVERRIDE_URL);
-    child.kill('SIGINT');
-    process.exit(1);
-  });
+export const run = async (moduleAbsolutePath: string) => {
+  await lib.patchServerInit(moduleAbsolutePath);
+  await lib.run();
 };

--- a/src/injected.ts
+++ b/src/injected.ts
@@ -1,0 +1,19 @@
+const Mod = require('module');
+const req = Mod.prototype.require;
+
+Mod.prototype.require = function (...args) {
+  if (args[0] === 'konfig') {
+    return () => ({
+      app: {
+        api_url: process.env.CYPRESS_API_URL || 'https://api.cypress.io',
+        cdn_url: 'https://cdn.cypress.io',
+        chromium_manifest_url: 'https://download.cypress.io/chromium.json',
+        chromium_url: 'https://download.cypress.io/chromium',
+        desktop_manifest_url: 'https://download.cypress.io/desktop.json',
+        desktop_url: 'https://download.cypress.io/desktop',
+        on_url: 'https://on.cypress.io/',
+      },
+    });
+  }
+  return req.call(this, ...args);
+};

--- a/src/js.ts
+++ b/src/js.ts
@@ -1,0 +1,67 @@
+import { parse } from 'acorn';
+import escodegen from 'escodegen';
+import estraverse from 'estraverse';
+import { Program } from 'estree';
+
+export const parseJS = (code: string) =>
+  parse(code, { ecmaVersion: 2020 }) as unknown as Program;
+export const FN_ID = 'cy2_injected';
+
+export const instrumentCypressInit = (
+  code: string,
+  injectedModulePath: string
+) => {
+  const injectedFn = `
+function ${FN_ID}() {
+    try { require('${injectedModulePath}'); }
+    catch (e) {}
+}`;
+
+  const injectedCode = `(${injectedFn})();`;
+
+  const ast = parseJS(code);
+
+  if (!hasInjected(ast)) {
+    return escodegen.generate(injectAST(ast, parseJS(injectedCode)));
+  }
+
+  return escodegen.generate(replaceAST(ast, parseJS(injectedFn)));
+};
+
+export function hasInjected(ast: Program) {
+  let found = false;
+  estraverse.traverse(ast, {
+    enter: function (node) {
+      if (node.type == estraverse.Syntax.Identifier && node.name === FN_ID) {
+        found = true;
+        return this.break();
+      }
+    },
+  });
+  return found;
+}
+
+function injectAST(ast: Program, injectedAst: Program) {
+  estraverse.traverse(ast, {
+    enter: function (node) {
+      if (node.type === estraverse.Syntax.Program) {
+        node.body.unshift(injectedAst.body[0]);
+        return this.break();
+      }
+    },
+  });
+  return ast;
+}
+
+function replaceAST(ast: Program, injectedFnAst: Program) {
+  return estraverse.replace(ast, {
+    enter: function (node) {
+      if (
+        node.type == estraverse.Syntax.FunctionExpression &&
+        node.id.name === FN_ID
+      ) {
+        return injectedFnAst.body[0];
+      }
+    },
+  });
+}

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -1,5 +1,6 @@
 import cp from 'child_process';
 import fs from 'fs';
+import { instrumentCypressInit } from './js';
 
 import yaml from 'js-yaml';
 import { getCypressCLIBinPath } from './bin-path';
@@ -18,22 +19,8 @@ export async function patchServerInit(injectedAbsolutePath: string) {
 
   const doc = fs.readFileSync(serverInitPath, 'utf8');
 
-  if (doc.includes(injectedAbsolutePath)) {
-    return;
-  }
-
-  fs.writeFileSync(
-    serverInitPath,
-    `
-try {
-  require('${injectedAbsolutePath}');
-} catch (e) {
-  // noop
-}
-
-${doc}
-    `
-  );
+  const result = instrumentCypressInit(doc, injectedAbsolutePath);
+  fs.writeFileSync(serverInitPath, result);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,6 +858,11 @@
   dependencies:
     "@types/ms" "*"
 
+"@types/estree@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
+  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1018,6 +1023,11 @@ acorn@^8.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.2.tgz#c4574e4fea298d6e6ed4b85ab844b06dd59f26d6"
   integrity sha512-VrMS8kxT0e7J1EX0p6rI/E0FbfOVcvBpbIqHThFv+f8YrZIlMfVotYcXKVPmTvPW8sW5miJzfUFrrvthUZg8VQ==
 
+acorn@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
+
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
@@ -1098,11 +1108,6 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
-
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
-  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2272,6 +2277,11 @@ estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estraverse@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -3857,13 +3867,6 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
-  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
-  dependencies:
-    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
- Starting version 3+, the API methods `run` and `patch` rely on `process.env.CYPRESS_API_URL` - they do not accept any argument. That's because of a new patching method that doesn't permanently change cypress installation after invoking `cy2`.
- CLI executable script `cy2` requires CYPRESS_API_URL environment variable, otherwise throws