### PR TITLE
Use the right upstream chain protocol

### DIFF
--- a/.github/workflows/e2e-network.yaml
+++ b/.github/workflows/e2e-network.yaml
@@ -51,13 +51,13 @@ jobs:
       - name: Record with upstream proxy
         working-directory: ./e2e
         env:
-          HTTP_PROXY: https://localhost:9999
+          HTTP_PROXY: http://localhost:9999
         run: |
           ../bin/cy2 run --parallel --record --key xxx
 
       - name: Bypass upstream proxy for director
         env:
-          HTTP_PROXY: https://localhost:9999
+          HTTP_PROXY: http://localhost:9999
           NO_PROXY: localhost
         working-directory: ./e2e
         run: |

--- a/src/__test__/proxy-setting.upstream.spec.ts
+++ b/src/__test__/proxy-setting.upstream.spec.ts
@@ -34,24 +34,26 @@ describe('Upstream proxy settings', () => {
     expect(getUpstreamProxy({})).toBe(null);
   });
 
-  it('warn if protocol mismtach HTTPS_PROXY <> http://', async () => {
+  it('warn if protocol mismatch HTTPS_PROXY <> http://', async () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
     getUpstreamProxy({
       HTTPS_PROXY: 'http://localhost:1234',
     });
     expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('WARNING'),
-      expect.stringMatching('Mismatch between protocol')
+      expect.stringMatching('WARNING'),
+      expect.stringMatching('Mismatch between protocol'),
+      expect.anything()
     );
   });
-  it('warn if protocol mismtach HTTP_PROXY <> https://', async () => {
+  it('warn if protocol mismatch HTTP_PROXY <> https://', async () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
     getUpstreamProxy({
       HTTP_PROXY: 'httpS://localhost:1234',
     });
     expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('WARNING'),
-      expect.stringMatching('Mismatch between protocol')
+      expect.stringMatching('WARNING'),
+      expect.stringMatching('Mismatch between protocol'),
+      expect.anything()
     );
   });
 });

--- a/src/__test__/proxy-setting.upstream.spec.ts
+++ b/src/__test__/proxy-setting.upstream.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from '@jest/globals';
+import { URL } from 'url';
+import { getUpstreamProxy } from '../proxy-settings';
+
+let originalEnv = process.env;
+
+const HTTPS_PROXY = 'https://localhost:1234';
+const HTTP_PROXY = 'http://localhost:1234';
+
+describe('Upstream proxy settings', () => {
+  beforeEach(() => {
+    // restore the original env
+    process.env = { ...originalEnv };
+  });
+
+  it('prefers HTTPS_PROXY', async () => {
+    expect(
+      getUpstreamProxy({
+        HTTPS_PROXY,
+        HTTP_PROXY,
+      })
+    ).toEqual(new URL(HTTPS_PROXY));
+  });
+
+  it('prefers HTTP_PROXY', async () => {
+    expect(
+      getUpstreamProxy({
+        HTTP_PROXY,
+      })
+    ).toEqual(new URL(HTTP_PROXY));
+  });
+
+  it('returns null if none set', async () => {
+    expect(getUpstreamProxy({})).toBe(null);
+  });
+
+  it('warn if protocol mismtach HTTPS_PROXY <> http://', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    getUpstreamProxy({
+      HTTPS_PROXY: 'http://localhost:1234',
+    });
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('WARNING'),
+      expect.stringMatching('Mismatch between protocol')
+    );
+  });
+  it('warn if protocol mismtach HTTP_PROXY <> https://', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    getUpstreamProxy({
+      HTTP_PROXY: 'httpS://localhost:1234',
+    });
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('WARNING'),
+      expect.stringMatching('Mismatch between protocol')
+    );
+  });
+});

--- a/src/log.ts
+++ b/src/log.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import util from 'util';
 
 export const warn = (...args: Parameters<typeof util.format>) =>
-  console.warn(chalk.bgYellow.black(' WARNING '), util.format(...args));
+  console.warn(chalk.bgYellow.black('\n WARNING '), util.format(...args), '\n');
 
 export const error = (...args: Parameters<typeof util.format>) =>
-  console.warn(chalk.bgRed.black('\n ERROR '), util.format(...args));
+  console.warn(chalk.bgRed.black('\n ERROR '), util.format(...args), '\n');

--- a/src/proxy-chain.ts
+++ b/src/proxy-chain.ts
@@ -1,29 +1,32 @@
-import https from 'http';
+import http from 'http';
+import https from 'https';
 import net from 'net';
 import { debugNet } from './debug';
 
 export function runProxyChain(
-  req: https.IncomingMessage,
+  req: http.IncomingMessage,
   socket: net.Socket,
   upstreamProxy: URL
 ) {
   debugNet('Proxy chain to upstream for', req.url);
 
-  https
-    .request({
-      method: 'CONNECT',
-      path: req.url,
-      headers: req.headers,
-      agent: false,
-      hostname: upstreamProxy.hostname,
-      port: upstreamProxy.port,
-      protocol: upstreamProxy.protocol,
-    })
-    .once('upgrade', onUpgrade)
-    .once('connect', onConnect)
-    .once('error', onError)
-    .once('response', onResponse)
-    .end();
+  upstreamProxy.protocol === 'https:'
+    ? https
+    : http
+        .request({
+          method: 'CONNECT',
+          path: req.url,
+          headers: req.headers,
+          agent: false,
+          hostname: upstreamProxy.hostname,
+          port: upstreamProxy.port,
+          protocol: upstreamProxy.protocol,
+        })
+        .once('upgrade', onUpgrade)
+        .once('connect', onConnect)
+        .once('error', onError)
+        .once('response', onResponse)
+        .end();
 
   function onResponse(res) {
     res.upgrade = true;

--- a/src/tunnel-proxy.ts
+++ b/src/tunnel-proxy.ts
@@ -2,37 +2,45 @@ import http from 'http';
 import net from 'net';
 
 // a simple upstream tunnel proxy for testing
-http
-  .createServer()
-  .on('connect', (req, socket) => {
-    console.log('CONNECT', req.url);
-    const [host, port = '443'] = req.url!.split(':');
-    const socketToTarget = net.connect(parseInt(port, 10), host);
 
-    socketToTarget.on('ready', () => {
-      socketToTarget.pipe(socket);
-      socket.pipe(socketToTarget);
-      socket.write('HTTP/1.1 200 OK\r\n\r\n');
-    });
+async function main() {
+  http
+    .createServer()
+    .on('connect', (req, socket) => {
+      console.log('CONNECT', req.url);
+      const [host, port = '443'] = req.url!.split(':');
+      const socketToTarget = net.connect(parseInt(port, 10), host);
 
-    socket.on('end', () => {
-      socketToTarget.end();
-    });
+      socketToTarget.on('ready', () => {
+        socketToTarget.pipe(socket);
+        socket.pipe(socketToTarget);
+        socket.write('HTTP/1.1 200 OK\r\n\r\n');
+      });
 
-    socketToTarget.on('end', () => {
-      socket.end();
-    });
+      socket.on('end', () => {
+        socketToTarget.end();
+      });
 
-    socketToTarget.on('error', (err) => {
-      socketToTarget.end();
-      socket.end();
-    });
+      socketToTarget.on('end', () => {
+        socket.end();
+      });
 
-    socket.on('error', (err) => {
-      socketToTarget.end();
-      socket.end();
+      socketToTarget.on('error', (err) => {
+        socketToTarget.end();
+        socket.end();
+      });
+
+      socket.on('error', (err) => {
+        socketToTarget.end();
+        socket.end();
+      });
+    })
+    .listen(9999, () => {
+      console.log('upstream proxy listening on 9999');
     });
-  })
-  .listen(9999, () => {
-    console.log('upstream proxy listening on 9999');
-  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
- Resolve #54
- Use `https` or `http` for connecting to the upstream proxy
- Warn if there's a mismatch between env var and the protocol