### PR TITLE
fix: use HTTPS_PROXY by default

### DIFF
--- a/src/__test__/run-env.spec.ts
+++ b/src/__test__/run-env.spec.ts
@@ -36,7 +36,7 @@ describe('Run env', () => {
     );
   });
 
-  it('populates HTTP_PROXY when no pre-existing env variables', async () => {
+  it('populates HTTPS_PROXY when no pre-existing env variables', async () => {
     const port = randomPort();
     jest.spyOn(proxy, 'startProxy').mockResolvedValue({
       port,
@@ -45,19 +45,20 @@ describe('Run env', () => {
     await run(target, {});
 
     expect(process.env).toMatchObject({
-      HTTP_PROXY: `http://127.0.0.1:${port}`,
+      HTTPS_PROXY: `http://127.0.0.1:${port}`,
     });
   });
 
   it('removes "undefined" variables', async () => {
     const port = randomPort();
+    process.env.HTTP_PROXY = 'http://undefined.proxy/';
     jest.spyOn(proxy, 'startProxy').mockResolvedValue({
       port,
       stop: async () => {},
     });
 
     await run(target, {});
-    expect(process.env).not.toHaveProperty('HTTPS_PROXY');
+    expect(process.env).not.toHaveProperty('HTTP_PROXY');
   });
 
   it('use HTTPS_PROXY as upstream proxy', async () => {

--- a/src/cypress-wrapper.ts
+++ b/src/cypress-wrapper.ts
@@ -11,7 +11,7 @@ import {
   getProxySettings,
   getSanitizedEnvironment,
   getUpstreamProxy,
-  overrideRuntimeEnvVariabes,
+  overrideProcessEnv,
 } from './proxy-settings';
 
 /**
@@ -83,9 +83,7 @@ export async function run(
   });
   try {
     const settings = getProxySettings({ port });
-    overrideRuntimeEnvVariabes(
-      getEnvOverrides(settings.proxyURL, envVariables)
-    );
+    overrideProcessEnv(getEnvOverrides(settings.proxyURL, envVariables));
     process.env.NODE_EXTRA_CA_CERTS = settings.caPath;
     return await cypress.run(config);
   } finally {

--- a/src/http-proxy/lib/http-proxy/index.js
+++ b/src/http-proxy/lib/http-proxy/index.js
@@ -125,14 +125,6 @@ function createRightProxy(type) {
          * refer to the connection socket
          * pass(req, socket, options, head)
          */
-        debugHttpProxy(
-          'applying pass type "%s", #%d %s: %s %s',
-          type,
-          i,
-          passes[i].name,
-          req.method,
-          req.url
-        );
         if (passes[i](req, res, requestOptions, head, this, cbl)) {
           // passes can return a truthy value to halt the loop
           debugHttpProxy(

--- a/src/proxy-settings.ts
+++ b/src/proxy-settings.ts
@@ -146,16 +146,18 @@ export function getEnvOverrides(
 ): Partial<Record<string, string>> {
   return chain({
     ...envVariables,
-    HTTP_PROXY: currentsProxyURL,
-    HTTPS_PROXY: envVariables.HTTPS_PROXY ? currentsProxyURL : undefined,
+    // They use outdated `@cyrpress/request` for uploading artifacts
+    // it doesn't like HTTP_PROXY for some reason.
+    // That affects sorry-cypress users with `http:` storage urls
+    // see https://github.com/sorry-cypress/cy2/issues/47
+    HTTP_PROXY: undefined,
+    HTTPS_PROXY: currentsProxyURL,
   })
     .tap((o) => debug('Resolved proxy environment variables %o', o))
     .value();
 }
 
-export function overrideRuntimeEnvVariabes(
-  newEnv: Partial<Record<string, string>>
-) {
+export function overrideProcessEnv(newEnv: Partial<Record<string, string>>) {
   Object.entries(newEnv).forEach(([key, value]) => {
     if (isUndefined(value)) {
       debug('Deleting env %s', key);


### PR DESCRIPTION
- allow sorry-cypress users to upload to `http:` destinations
- reduce http-proxy verbosity