### PR TITLE
adds ssl false configuration option to httpProxy createProxyServer co…

### DIFF
--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -95,6 +95,7 @@ function createInterceptor({
         changeOrigin: true,
         followRedirects: true,
         agent,
+        secure: false,
         ssl: {
           key,
           cert,


### PR DESCRIPTION
…mmand

Cy2 will error if it is being redirected to a server that has a self signed certificate. Given the nature of this application, I dont see why Cy2 should care if the SSL certificate on the API server is a valid certificate therefore I have disabled this check by setting the configuration value "secure" to the value of "false".

https://github.com/sorry-cypress/cy2/tree/12140cde58df9bea079950ce03ae69ca83dc34c8/src/http-proxy#using-https