### PR TITLE
Azure blob type header

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ import { spawn } from 'cy2';
 await spawn(process.env.CYPRESS_API_URL);
 ```
 
+## Azure blob storage support
+
+Azure requires a `x-ms-blob-type` header to be present when uploading build artifacts to a storage account, in order to have these headers added to the upload requests configure the `AZURE_BLOB_URL` environment variable with the hostname associated with your Azure storage account.
+
+Example:
+
+```sh
+AZURE_BLOB_URL=https://your-storage-account.blob.core.windows.net
+```
+
 ## Breaking Changes
 
 ### Version 4

--- a/src/azure-blob-interceptor.ts
+++ b/src/azure-blob-interceptor.ts
@@ -1,0 +1,113 @@
+import type httpProxyType from 'http-proxy';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { cert, key } from './cert';
+import { debugNet } from './debug';
+import * as httpProxy from './http-proxy';
+import { warn } from './log';
+
+const interceptors = new Map<'upstream' | 'direct', httpProxyType>();
+
+export async function stopAzureBlobInterceptors() {
+  debugNet('Stopping Azure blob interceptors');
+  await Promise.all(
+    Array.from(interceptors.values()).map(
+      (interceptor, i, all): Promise<void> =>
+        new Promise((resolve) =>
+          interceptor.close(() => {
+            debugNet('Stopped Azure blob interceptor %d/%d', i + 1, all.length);
+            resolve();
+          })
+        )
+    )
+  );
+  interceptors.clear();
+}
+
+export async function getUpstreamAzureBlobInterceptor({
+  target,
+  upstreamProxy,
+}: {
+  target: string;
+  upstreamProxy: URL;
+}) {
+  if (interceptors.has('upstream')) {
+    debugNet(
+      'Using Azure blob interceptor with upstream routing',
+      upstreamProxy.toString(),
+      target
+    );
+    return interceptors.get('upstream');
+  }
+  debugNet(
+    'Creating Azure blob interceptor with upstream routing path: %s -> %s',
+    upstreamProxy.toString(),
+    target
+  );
+  const agent = new HttpsProxyAgent({
+    protocol: upstreamProxy.protocol, // connect to upstreamProxy over https
+    host: upstreamProxy.hostname,
+    port: upstreamProxy.port,
+    path: upstreamProxy.pathname,
+  });
+
+  interceptors.set(
+    'upstream',
+    await createInterceptor({
+      target,
+      agent,
+    })
+  );
+  return interceptors.get('upstream');
+}
+
+export async function getDirectAzureBlobInterceptor({
+  target,
+}: {
+  target: string;
+}): Promise<httpProxyType> {
+  if (interceptors.has('direct')) {
+    debugNet('Using Azure blob interceptor with direct routing');
+    return interceptors.get('direct') as httpProxyType;
+  }
+  debugNet('Creating Azure blob interceptor with direct routing path: %s', target);
+  interceptors.set(
+    'direct',
+    await createInterceptor({
+      target,
+    })
+  );
+  return interceptors.get('direct') as httpProxyType;
+}
+
+function createInterceptor({
+  target,
+  agent,
+}: {
+  target: string;
+  agent?: HttpsProxyAgent;
+}): Promise<httpProxyType> {
+  return new Promise((resolve) => {
+    debugNet('Creating Azure blob interceptor for %s', target);
+    const i = httpProxy
+      // @ts-ignore
+      .createProxyServer({
+        target,
+        agent,
+        ssl: {
+          key,
+          cert,
+        },
+      })
+      .on("proxyReq", (proxyReq) => {
+        proxyReq.setHeader("x-ms-blob-type", "BlockBlob");
+        debugNet('Added x-ms-blob-type header to Azure blob request')
+      })
+      .on('error', (err) => {
+        const type = Boolean(agent) ? 'upstream proxy' : 'direct';
+        debugNet('Azure blob interceptor of type %s error: %s', type, err);
+        warn('Error connecting to %s: %s', target, err.message);
+      });
+
+    i.listen(0, undefined, () => resolve(i));
+  });
+}


### PR DESCRIPTION
Adds a second set of interceptors that add the `x-ms-blob-type` header to artifact upload requests to Azure storage when the AZURE_BLOB_URL environment variable is configured.

The CLI complains about not being able to confirm the upload of artifacts but both videos and screenshots are properly uploaded to the storage account and they do show up in our sorry-cypress dashboard. I suspect this has to do with an API endpoint that is not implemented by the sorry-cypress director.
```
Warning: We encountered an error while confirming the upload of artifacts.

These results will not display artifacts.

This error will not affect or change the exit code.

StatusCodeError: 404 - "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot PUT /instances/e1617adc-01e3-4568-9910-97f8ca1dbbbd/artifacts</pre>\n</body>\n</html>\n"
```

Tested on Windows 11 with Cypress 13.6.0